### PR TITLE
Update 2021-12-28-emf-2022-ticket-sales.md

### DIFF
--- a/_posts/2021-12-28-emf-2022-ticket-sales.md
+++ b/_posts/2021-12-28-emf-2022-ticket-sales.md
@@ -2,6 +2,8 @@
 layout: post
 title: "Electromagnetic Field 2022 Ticket Sales"
 ---
+**Update**: [Ticket sale dates have been announced](https://blog.emfcamp.org/2022/02/16/emf-2022-ticket-sale-dates-and-cfp/)!
+
 We are almost ready to begin ticket sales for EMF 2022!
 
 If you had a ticket for EMF 2020 you will receive a voucher by email allowing you to purchase a ticket for EMF 2022. We'll be sending these in the coming weeks, and they will be valid for one month - once your voucher has expired you will have to buy tickets in the public sale.


### PR DESCRIPTION
Pezmc> Pez 
I think the tickets link on https://www.emfcamp.org/tickets needs to be updated to point to https://blog.emfcamp.org/2022/02/16/emf-2022-ticket-sale-dates-and-cfp/ (and/or the article it currently links to should point there).